### PR TITLE
Add a reference to the RSS feed in head template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,11 @@
 <meta name="renderer" content="webkit">
 <meta name="theme-color" content="#ffffff">
 
+<!-- rss feed -->
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}
+
 <!-- open-graph -->
 {{if .Site.Params.enableOpenGraph}}
 {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
basically did this in layouts/partials/head.html
https://gohugo.io/templates/rss/#include-feed-reference

If you're wondering why I bothered it's because that link element makes it easier to discover your RSS feed.